### PR TITLE
Rename GCR-specific field to `GCR`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ exposing to the internet, because
  - `GoogleContainerRegistry` image push events via pubsub
  - `Nexus` image push events
 
+Some of these have specific configuration options; see
+[Source-specific configuration](#source-specific-configuration) below.
+
 ## How to use it
 
 In short:
@@ -143,7 +146,7 @@ though you may want to supply the argument `--listen=localhost:3030`
 to limit API access to localhost, if you don't already.
 
 > If you do restrict API access to localhost, make sure you also
-> 
+>
 >  - supply `--listen-metrics=:3031`
 >  - annotate the pod with `prometheus.io/port: "3031"`, so
 >    Prometheus knows which port to scrape).
@@ -306,3 +309,22 @@ trigger to refresh state, rather than as authoritative themselves. For
 example, when informed of an image push, fluxd does not add the image
 mentioned to its database -- it polls the image registry in question
 to determine whether there is a new image.
+
+### Source-specific configuration
+
+#### Google Container Registry
+
+The Google Container Registry endpoint expects a [push
+subscription](https://cloud.google.com/pubsub/docs/push) to be set
+up. If you include a `gcr` field in the endpoint configuration, it
+will authenticate and verify the audience for incoming webhook
+payloads:
+
+```
+fluxRecvVersion: 1
+endpoints:
+- source: GoogleContainerRegistry
+  keyPath: gcr.key
+  gcr:
+    audience: flux-push-notification
+```

--- a/config.go
+++ b/config.go
@@ -7,15 +7,15 @@ import (
 	"github.com/ghodss/yaml"
 )
 
-type Auth struct {
+type GCRAuth struct {
 	Audience string `json:"audience"`
 }
 
 type Endpoint struct {
-	Source         string `json:"source"`
-	RegistryHost   string `json:"registryHost,omitempty"`
-	KeyPath        string `json:"keyPath"`
-	Authentication *Auth  `json:"authentication,omitempty"`
+	Source       string   `json:"source"`
+	RegistryHost string   `json:"registryHost,omitempty"`
+	KeyPath      string   `json:"keyPath"`
+	GCR          *GCRAuth `json:"gcr,omitempty"`
 }
 
 type Config struct {

--- a/gcr.go
+++ b/gcr.go
@@ -40,8 +40,8 @@ func init() {
 
 func handleGoogleContainerRegistry(s fluxapi.Server, _ []byte, w http.ResponseWriter, r *http.Request, config Endpoint) {
 	// authenticate based on config
-	if config.Authentication != nil {
-		if err := authenticateRequest(&http.Client{}, r.Header.Get("Authorization"), config.Authentication.Audience); err != nil {
+	if config.GCR != nil {
+		if err := authenticateRequest(&http.Client{}, r.Header.Get("Authorization"), config.GCR.Audience); err != nil {
 			http.Error(w, "Cannot authorize request", http.StatusOK)
 			log(GoogleContainerRegistry, err.Error())
 			return

--- a/sources_test.go
+++ b/sources_test.go
@@ -398,7 +398,7 @@ func Test_GoogleContainerRegistry_WhenNoAuth(t *testing.T) {
 	downstream := newDownstream(t, expectedGoogleContainerRegistry, &called)
 	defer downstream.Close()
 
-	endpoint := Endpoint{Source: GoogleContainerRegistry, KeyPath: "gcr_key", Authentication: nil}
+	endpoint := Endpoint{Source: GoogleContainerRegistry, KeyPath: "gcr_key", GCR: nil}
 	fp, handler, err := HandlerFromEndpoint("test/fixtures", downstream.URL, endpoint)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
The `audience` field is specific to GoogleCloudRegistry endpoints rather
than being generic, so let's just name it for GCR. An endpoint config
will then look like this:

    endpoints:
    - keyPath: gcr.key
      source: GoogleContianerRegistry
      gcr:
        audience: gcr-push