### PR TITLE
Harbor v2 support

### DIFF
--- a/harbor.go
+++ b/harbor.go
@@ -36,7 +36,7 @@ func handleHarbor(s fluxapi.Server, key []byte, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	if p.Type != "pushImage" {
+	if p.Type != "pushImage" && p.Type != "PUSH_ARTIFACT" {
 		http.Error(w, "Unexpected event type", http.StatusBadRequest)
 		log(Harbor, "unexpected event type:", p.Type)
 		return

--- a/test/fixtures/harborV2_key
+++ b/test/fixtures/harborV2_key
@@ -1,0 +1,1 @@
+f4f1e8fcd09bc07a397df58b3a2af9ed9414e39b

--- a/test/fixtures/harborV2_payload
+++ b/test/fixtures/harborV2_payload
@@ -1,0 +1,19 @@
+{
+	"type": "PUSH_ARTIFACT",
+	"occur_at": 1586922308,
+	"operator": "admin",
+	"event_data": {
+		"resources": [{
+			"digest": "sha256:8a9e9863dbb6e10edb5adfe917c00da84e1700fa76e7ed02476aa6e6fb8ee0d8",
+			"tag": "latest",
+			"resource_url": "hub.harbor.com/test-webhook/debian:latest"
+		}],
+		"repository": {
+			"date_created": 1586922308,
+			"name": "debian",
+			"namespace": "test-webhook",
+			"repo_full_name": "test-webhook/debian",
+			"repo_type": "private"
+		}
+	}
+}


### PR DESCRIPTION
Hi, I was trying to setup flux-recv for an harbor v2.0.0 but I was getting an error message `Harbor unexpected event type: PUSH_ARTIFACT`

Harbor V2 modify the event type in its payload sent to a webhook from [imagePush](https://goharbor.io/docs/1.10/working-with-projects/project-configuration/configure-webhooks/#json-payload-format) to [PUSH_ARTIFACT](https://goharbor.io/docs/2.0.0/working-with-projects/project-configuration/configure-webhooks/#payload-format).

This PR update event type check  for harbor by allowing `PUSH_ARTIFACT` as well as `pushImage` since based on the test file in this repo the payload are essentially the same apart from the type. 

I was able to test successfully with a couple local harbor instances (1.10.0 and 2.1.0) however I'm a bit confused why this work because looking at the doc for Harbor v1.10.0 the payload structure looks completely different.